### PR TITLE
HSTS: set includeSubDomains and preload

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,11 @@
   to = "/404.html"
   status = 404
   force = false
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = '''
+    max-age=63072000;
+    includeSubDomains;
+    preload'''


### PR DESCRIPTION
This enables HSTS for all subdomains of divviup.org, (i.e., API subdomains) and prepares the domain for addition to the [HSTS preload list](https://hstspreload.org/). The configuration stanza was taken from https://docs.netlify.com/domains-https/https-ssl/#hsts-preload.

See also divviup/janus-ops#192.