### PR TITLE
*: use telemetry service tagline

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ address = "548 Market St, PMB 77519, San Francisco, California 94104-5401"
 address_line_1 = "548 Market St, PMB 77519"
 address_line_2 = "San Francisco, California 94104-5401"
 images = ["images/DivviUpSocialShare.png"]
-meta_description = "Divvi Up is a privacy-respecting system for the collection of aggregate statistics such as application metrics, brought to you by the Internet Security Research Group."
+meta_description = "Divvi Up is a privacy-respecting telemetry service for web, mobile, and machine learning applications, brought to you by the Internet Security Research Group."
 social_share_twitter_square = "images/DivviUpSocialShare-Twitter.png"
 promoAnnouncementEnabled = false
 # Previous usage of promoAnnouncementLink and promoAnnouncementText
@@ -42,5 +42,5 @@ languageName ="English"
 # Weight used for sorting.
 weight = 1
 [languages.en.params]
-description = "Divvi Up is a privacy-respecting system for the collection of aggregate statistics such as application metrics, brought to you by the Internet Security Research Group."
+description = "Divvi Up is a privacy-respecting telemetry service for web, mobile, and machine learning applications, brought to you by the Internet Security Research Group."
 

--- a/content/en/about.html
+++ b/content/en/about.html
@@ -6,10 +6,10 @@ description: Learn about Divvi Up, how it works, how it got started, and the ope
 
 <section class="slice slice-sm">
   <div class="container">
-    <p>Divvi Up is a privacy-respecting system for the collection of aggregate statistics such as application metrics.</p>
+    <p>Divvi Up is a privacy-respecting telemetry service for web, mobile, and machine learning applications.</p>
     <p>
       Applications such as web browsers, mobile applications, or websites generate data. Normally they would just send all of the data back to the application developer, but applications using Divvi Up will split the data into two anonymized and encrypted shares and upload each share to different data share processors that do not share data with each other. This way only minimal information about the original data is revealed to either processor. Each processor then aggregates its data shares
-      into a partial sum. The partial sums can then be combined into a final aggregation, permitting useful statistics over the whole body of data while revealing minimal information about individual participants. This system is based on the <a href="https://crypto.stanford.edu/prio/" target="_blank">Prio</a> protocol developed at Stanford by Henry Corrigan-Gibbs and Dan Boneh.
+      into a partial sum. The partial sums can then be combined into a final aggregation, permitting useful statistics or averages over the whole body of data while revealing minimal information about individual participants. This system is based on the <a href="https://crypto.stanford.edu/prio/" target="_blank">Prio</a> protocol developed at Stanford by Henry Corrigan-Gibbs and Dan Boneh.
     </p>
   </div>
 </section>

--- a/layouts/partials/divvi/divvi_home_hero.html
+++ b/layouts/partials/divvi/divvi_home_hero.html
@@ -5,8 +5,8 @@
         class="col-md-5 align-self-center d-flex justify-content-lg-start justify-content-center mt-xl-n5 pt-lg-6 text-md-start text-center"
       >
         <div class="pb-3 pt-md-3 pb-md-3" style="max-width: 460px">
-          <h1 class="text-white display-4 mb-lg-5">
-            Divvi Up: A privacy-respecting system for aggregate statistics
+          <h1 class="text-white display-3 mb-lg-5">
+            Divvi Up: A privacy respecting telemetry service
           </h1>
         </div>
       </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
         <div class="row">
           <div class="col-lg-5 offset-lg-0 col-md-8 col-sm-6 mb-sm-0 mb-4">
 
-<p>Divvi Up is a privacy-respecting metrics service brought to you by the nonprofit <a href="https://abetterinternet.org">Internet Security Research Group (ISRG)</a>, which operates the <a href="https://letsencrypt.org">Let’s Encrypt</a> and <a href="https://memorysafety.org">Prossimo</a> projects. Read all about our nonprofit work this year in our <a href='https://abetterinternet.org/annual-reports'>2023 Annual Report</a>.</p>
+<p>Divvi Up is a privacy-respecting telemetry service brought to you by the nonprofit <a href="https://abetterinternet.org">Internet Security Research Group (ISRG)</a>, which operates the <a href="https://letsencrypt.org">Let’s Encrypt</a> and <a href="https://memorysafety.org">Prossimo</a> projects. Read all about our nonprofit work this year in our <a href='https://abetterinternet.org/annual-reports'>2023 Annual Report</a>.</p>
             <br />
 
                 <a class="nav-link me-lg-0 me-sm-4 p-0 fw-normal" href="https://www.abetterinternet.org/trademarks" target="_isrg-trademarks">Trademark Policy <i class="ci-external-link mt-n1 ms-2"></i></a>


### PR DESCRIPTION
Replace mentions of statistics/metrics/etc with telemetry service throughout the website.

This leaves blog posts untouched.